### PR TITLE
Prevent visual feedback when readonly is true

### DIFF
--- a/Tags/Tag.js
+++ b/Tags/Tag.js
@@ -24,7 +24,8 @@ const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle, readonly }) => {
 
 Tag.propTypes = {
   label: PropTypes.string.isRequired,
-  onPress: PropTypes.func
+  onPress: PropTypes.func,
+  readonly: PropTypes.bool
 };
 
 export default Tag;

--- a/Tags/Tag.js
+++ b/Tags/Tag.js
@@ -4,8 +4,8 @@ import { View, Text, TextInput, TouchableOpacity } from "react-native";
 
 import styles from "./styles";
 
-const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle }) => (
-  <TouchableOpacity style={[styles.tag, tagContainerStyle]} onPress={onPress}>
+const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle, readonly }) => (
+  <TouchableOpacity style={[styles.tag, tagContainerStyle]} onPress={onPress} activeOpacity={readonly ? 1 : 0.2 }>
     <Text style={[styles.tagLabel, tagTextStyle]}>{label}</Text>
   </TouchableOpacity>
 );

--- a/Tags/Tag.js
+++ b/Tags/Tag.js
@@ -9,7 +9,7 @@ const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle, readonly }) => {
 
   if (readonly) {
     return (
-      <View style={[styles.tag, tagContainerStyle]} onPress={onPress}>
+      <View style={[styles.tag, tagContainerStyle]}>
         {tagText}
       </View>
     )

--- a/Tags/Tag.js
+++ b/Tags/Tag.js
@@ -4,11 +4,23 @@ import { View, Text, TextInput, TouchableOpacity } from "react-native";
 
 import styles from "./styles";
 
-const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle, readonly }) => (
-  <TouchableOpacity style={[styles.tag, tagContainerStyle]} onPress={onPress} activeOpacity={readonly ? 1 : 0.2 }>
-    <Text style={[styles.tagLabel, tagTextStyle]}>{label}</Text>
-  </TouchableOpacity>
-);
+const Tag = ({ label, onPress, tagContainerStyle, tagTextStyle, readonly }) => {
+  const tagText = <Text style={[styles.tagLabel, tagTextStyle]}>{label}</Text>;
+
+  if (readonly) {
+    return (
+      <View style={[styles.tag, tagContainerStyle]} onPress={onPress}>
+        {tagText}
+      </View>
+    )
+  } else {
+    return (
+      <TouchableOpacity style={[styles.tag, tagContainerStyle]} onPress={onPress}>
+        {tagText}
+      </TouchableOpacity>
+    )
+  }
+}
 
 Tag.propTypes = {
   label: PropTypes.string.isRequired,

--- a/Tags/index.js
+++ b/Tags/index.js
@@ -77,6 +77,7 @@ class Tags extends React.Component {
             key={i}
             label={tag}
             onPress={e => this.props.onTagPress(i, tag, e)}
+            readonly={this.props.readonly}
             tagContainerStyle={this.props.tagContainerStyle}
             tagTextStyle={this.props.tagTextStyle}
           />


### PR DESCRIPTION
When readonly is true, the tags still show a visual feedback (opacity). This could confuse end-users to thinking something should happen. Setting the opacity to 1 if readonly is true (no visual feedback) prevents any visual feedback.

0.2 when readonly is false is the default activeOpacity of the TouchableOpacity.